### PR TITLE
External pandoc and proc limiting

### DIFF
--- a/check.js
+++ b/check.js
@@ -1,0 +1,16 @@
+var debug     = require('debug')('metalsmith-pandoc');
+var which     = require('which');
+var fs        = require('fs');
+var pdc       = require('pdc');
+
+// use system installed pandoc first
+which('pandoc', function(err,cmd){
+  if (!err) {
+      debug('Found pandoc:' + cmd)
+      pdc.path = cmd;
+    }
+  else {
+    console.err('Please check that pandoc is installed on your system.')
+    process.exit(1);
+  }
+});

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function plugin(options){
     async.eachLimit(Object.keys(files), 100, function(file, cb){
       debug('Checking file: %s', file);
       debug('Multimatch: %s %s %s', file, pattern, match(file, pattern))
-      if (!match(file, pattern)) {
+      if (match(file, pattern) == 0) {
         cb(); // count
         return; // do nothing
       }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var basename  = require('path').basename;
 var dirname   = require('path').dirname;
 var extname   = require('path').extname;
 var debug     = require('debug')('metalsmith-pandoc');
-var pdcPath   = require('pandoc-bin').path;
 var pdc       = require('pdc');
 var minimatch = require('minimatch');
 var async     = require('async');
@@ -10,20 +9,15 @@ var which     = require('which');
 var fs        = require('fs');
 var platform  = require('os').platform;
 
-// use pandoc-bin
-pdc.path = pdcPath;
-// check if installation of pandoc-bin is ok
-fs.stat(pdcPath, function(err, stats){
-  if (err || !isExecutable(stats.mode)) {
-    console.log('metalsmith-pandoc: trouble with pandoc-bin installation');
-    console.log('metalsmith-pandoc: trying to use system installed pandoc');
-    // try to use system installed pandoc
-    which('pandoc', function(err,cmd){
-      if (!err) pdc.path = cmd;
-      else console.log('metalsmith-pandoc: ERROR pandoc not found');
-    });
+// use system installed pandoc
+which('pandoc', function(err,cmd){
+  if (!err) pdc.path = cmd;
+  else {
+    console.err('metalsmith-pandoc: Cannot find pandoc on the system. Please install it!');
+    process.exit(1)
   }
 });
+
 
 function isExecutable(mode){
   if (platform() === 'win32') return true;  // do not check +x on windows

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var dirname   = require('path').dirname;
 var extname   = require('path').extname;
 var debug     = require('debug')('metalsmith-pandoc');
 var pdc       = require('pdc');
-var minimatch = require('minimatch');
+var match     = require('multimatch');
 var async     = require('async');
 var which     = require('which');
 var fs        = require('fs');
@@ -49,8 +49,8 @@ function plugin(options){
   return function(files, metalsmith, done){
     async.eachLimit(Object.keys(files), 100, function(file, cb){
       debug('Checking file: %s', file);
-      debug('Minimatch: %s %s %s', file, pattern, minimatch(file, pattern))
-      if (!minimatch(file, pattern)) {
+      debug('Multimatch: %s %s %s', file, pattern, match(file, pattern))
+      if (!match(file, pattern)) {
         cb(); // count
         return; // do nothing
       }

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function plugin(options){
   return function(files, metalsmith, done){
     each(Object.keys(files), function(file, cb){
       debug('Checking file: %s', file);
-      debug('Minimatch:' %s %s %s, file, pattern, minimatch(file, pattern))
+      debug('Minimatch: %s %s %s', file, pattern, minimatch(file, pattern))
       if (!minimatch(file, pattern)) {
         cb(); // count
         return; // do nothing

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function plugin(options){
     async.eachLimit(Object.keys(files), 100, function(file, cb){
       debug('Checking file: %s', file);
       debug('Multimatch: %s %s %s', file, pattern, match(file, pattern))
-      if (match(file, pattern) == 0) {
+      if (match(file, pattern).length == 0) {
         cb(); // count
         return; // do nothing
       }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var platform  = require('os').platform;
 which('pandoc', function(err,cmd){
   if (!err) pdc.path = cmd;
   else {
-    console.err('metalsmith-pandoc: Cannot find pandoc on the system. Please install it!');
+    console.log('metalsmith-pandoc: Cannot find pandoc on the system. Please install it!');
     process.exit(1)
   }
 });

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ function plugin(options){
   return function(files, metalsmith, done){
     each(Object.keys(files), function(file, cb){
       debug('Checking file: %s', file);
+      debug('Minimatch:' %s %s %s, file, pattern, minimatch(file, pattern))
       if (!minimatch(file, pattern)) {
         cb(); // count
         return; // do nothing

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var debug     = require('debug')('metalsmith-pandoc');
 var pdcPath   = require('pandoc-bin').path;
 var pdc       = require('pdc');
 var minimatch = require('minimatch');
-var each      = require('async-each');
+var async     = require('async');
 var which     = require('which');
 var fs        = require('fs');
 var platform  = require('os').platform;
@@ -53,7 +53,7 @@ function plugin(options){
   var extension = options.ext || '.html';
 
   return function(files, metalsmith, done){
-    each(Object.keys(files), function(file, cb){
+    async.eachLimit(Object.keys(files), 100, function(file, cb){
       debug('Checking file: %s', file);
       debug('Minimatch: %s %s %s', file, pattern, minimatch(file, pattern))
       if (!minimatch(file, pattern)) {

--- a/package.json
+++ b/package.json
@@ -9,25 +9,24 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iilab/metalsmith-pandoc.git"
+    "url": "https://github.com/arve0/metalsmith-pandoc"
   },
   "keywords": [
     "pandoc",
     "markdown",
     "metalsmith"
   ],
-  "author": {
-    "name": "Jun Matsushita"
-  },
+  "author": "Arve Seljebu",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/iilab/metalsmith-pandoc/issues"
+    "url": "https://github.com/arve0/metalsmith-pandoc/issues"
   },
-  "homepage": "https://github.com/iilab/metalsmith-pandoc",
+  "homepage": "https://github.com/arve0/metalsmith-pandoc",
   "dependencies": {
     "async": "^2.0.0-rc.2",
     "debug": "^2.1.0",
     "multimatch": "^2.1.0",
+    "pandoc-bin": "arve0/pandoc-bin#f73e639",
     "pdc": "cherbst/node-pdc",
     "which": "^1.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async-each": "^0.1.6",
     "debug": "^2.1.0",
     "minimatch": "^2.0.1",
-    "pandoc-bin": "arve0/pandoc-bin#f73e639",
+    "pandoc-bin": "mastern2k3/pandoc-bin",
     "pdc": "^0.2.2",
     "which": "^1.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-pandoc",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Pandoc plugin for metalsmith",
   "main": "index.js",
   "scripts": {
@@ -8,24 +8,24 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/arve0/metalsmith-pandoc"
+    "url": "https://github.com/iilab/metalsmith-pandoc"
   },
   "keywords": [
     "pandoc",
     "markdown",
     "metalsmith"
   ],
-  "author": "Arve Seljebu",
+  "author": "Jun Matsushita",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/arve0/metalsmith-pandoc/issues"
+    "url": "https://github.com/iilab/metalsmith-pandoc/issues"
   },
-  "homepage": "https://github.com/arve0/metalsmith-pandoc",
+  "homepage": "https://github.com/iilab/metalsmith-pandoc",
   "dependencies": {
     "async-each": "^0.1.6",
     "debug": "^2.1.0",
     "minimatch": "^2.0.1",
-    "pandoc-bin": "mastern2k3/pandoc-bin",
+    "pandoc-bin": "iilab/pandoc-bin",
     "pdc": "^0.2.2",
     "which": "^1.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "async": "^2.0.0-rc.2",
     "debug": "^2.1.0",
-    "minimatch": "^2.0.1",
+    "multimatch": "^2.1.0",
     "pdc": "cherbst/node-pdc",
     "which": "^1.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -1,31 +1,33 @@
 {
   "name": "metalsmith-pandoc",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Pandoc plugin for metalsmith",
   "main": "index.js",
   "scripts": {
+    "postinstall": "node check.js",
     "test": "mocha"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iilab/metalsmith-pandoc"
+    "url": "git+https://github.com/iilab/metalsmith-pandoc.git"
   },
   "keywords": [
     "pandoc",
     "markdown",
     "metalsmith"
   ],
-  "author": "Jun Matsushita",
+  "author": {
+    "name": "Jun Matsushita"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/iilab/metalsmith-pandoc/issues"
   },
   "homepage": "https://github.com/iilab/metalsmith-pandoc",
   "dependencies": {
-    "async": "^1.5.2",
+    "async-each": "^0.1.6",
     "debug": "^2.1.0",
     "minimatch": "^2.0.1",
-    "pandoc-bin": "iilab/pandoc-bin",
     "pdc": "cherbst/node-pdc",
     "which": "^1.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/iilab/metalsmith-pandoc",
   "dependencies": {
-    "async-each": "^0.1.6",
+    "async": "^1.5.2",
     "debug": "^2.1.0",
     "minimatch": "^2.0.1",
     "pandoc-bin": "iilab/pandoc-bin",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "^2.1.0",
     "minimatch": "^2.0.1",
     "pandoc-bin": "iilab/pandoc-bin",
-    "pdc": "^0.2.2",
+    "pdc": "cherbst/node-pdc",
     "which": "^1.0.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/iilab/metalsmith-pandoc",
   "dependencies": {
-    "async-each": "^0.1.6",
+    "async": "^2.0.0-rc.2",
     "debug": "^2.1.0",
     "minimatch": "^2.0.1",
     "pdc": "cherbst/node-pdc",


### PR DESCRIPTION
Hi there,

I've been using this fork for  while now, which removes dependency to pandoc-bin and makes pandoc an external dependency. Even though it adds a manual installation step, it's really not a good practice to download binary blobs of the internet so it's probably preferable :)

Also I've added a dependency on async which is used for proc limiting, avoiding that pandoc processes are spawned too agressively.

Finally, a small change to use multimatch pattern matching for files instead of minimatch.

Cheers!

Jun
