### PR TITLE
Support for binary output

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-//https://github.com/goumang2010/node-pdc/blob/2b89fe72133cc3b93a45f175fe756085f54124f3/pdc.js modified metalsmith-pandoc that handles binary data 
 var basename  = require('path').basename;
 var dirname   = require('path').dirname;
 var extname   = require('path').extname;


### PR DESCRIPTION
Hi - I made this change since I needed epub output.  node-pdc assumes string output, but also offers pdc.stream to return a child_process, from which we can pull the output stream as binary data. This patch draws from https://github.com/goumang2010/node-pdc (thanks @goumang2010) and should address docx/pdf needs in issue #2 as well. It's my first time contributing to a repo, so please let me know if this is welcome or if there's a better way to do this.  Thanks!